### PR TITLE
Lookup mob.ini in parent folders and make prefix relative to .ini containing it

### DIFF
--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -502,6 +502,17 @@ int build_command::do_run()
 {
 	try
 	{
+		// Create a mob.ini in the build folder.
+		if (!exists(paths::prefix())) {
+			create_directory(paths::prefix());
+		}
+		auto prefix_ini = paths::prefix() / "mob.ini";
+		if (!exists(prefix_ini))
+		{
+			std::ofstream out(prefix_ini);
+			out << "[paths]\n" << "prefix = .\n";
+		}
+
 		run_all_tasks();
 
 		if (do_timings)


### PR DESCRIPTION
Since there is no easy way of checking if a `.ini` contains a `paths/prefix` entry in `find_inis`, I simply stop at the first `.ini` found, which should be enough.

The `init_options` is a bit more messy since I need to remember which `.ini` contained the `paths/prefix`. Maybe I could assume the last one in the list? But I still would have to check if the prefix is given in the command line.