### PR TITLE
Infinite loop without an ini somewhere in the parent path

### DIFF
--- a/src/core/conf.cpp
+++ b/src/core/conf.cpp
@@ -992,7 +992,12 @@ std::vector<fs::path> find_inis(
 				v.push_back({ "cwd", fs::canonical(in_cwd) });
 				break;
 			}
-			cwd = cwd.parent_path();
+
+			const auto parent = cwd.parent_path();
+			if (cwd == parent)
+				break;
+
+			cwd = parent;
 		}
 	}
 


### PR DESCRIPTION
Broken parent check, `parent_path()` returns `*this` when on the root.