### PR TITLE
Missing PRs from search

### DIFF
--- a/src/cmd/pr.cpp
+++ b/src/cmd/pr.cpp
@@ -226,7 +226,7 @@ std::vector<pr_command::pr_info> pr_command::search_prs(
 	nlohmann::json json;
 
 	constexpr auto* pattern =
-		"https://api.github.com/search/issues?q="
+		"https://api.github.com/search/issues?per_page=100&q="
 		"is:pr+org:{org:}+author:{author:}+is:open+head:{branch:}";
 
 	const auto search_url = ::fmt::format(


### PR DESCRIPTION
Added `per_page=100` for pr search, was limited to 30. If you have more than 100 matching PRs, go away.