### PR TITLE
Interrupting tasks and extracting sip

### DIFF
--- a/src/tasks/sip.cpp
+++ b/src/tasks/sip.cpp
@@ -124,13 +124,14 @@ void sip::do_fetch()
 	if (fs::exists(download_file()))
 	{
 		cx().trace(context::bypass, "sip: {} already exists", download_file());
-		return;
 	}
-
-	// download
-	run_tool(pip(pip::download)
-		.package("sip")
-		.version(version()));
+	else
+	{
+		// download
+		run_tool(pip(pip::download)
+			.package("sip")
+			.version(version()));
+	}
 
 	// extract
 	run_tool(extractor()

--- a/src/tasks/task_manager.cpp
+++ b/src/tasks/task_manager.cpp
@@ -103,7 +103,12 @@ void task_manager::run_all()
 	try
 	{
 		for (auto&& t : top_level_)
+		{
 			t->run();
+
+			if (interrupt_)
+				break;
+		}
 	}
 	catch(interrupted&)
 	{


### PR DESCRIPTION
- Stop running tasks when interrupted
- sip: don't skip extraction because the download exists