### PR TITLE
Add alias for translations of script_extender_plugin_checker.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -123,7 +123,6 @@ void add_tasks()
 		.add_task<mo>("modorganizer-basic_games")
 		.add_task<mo>({
 			"modorganizer-script_extender_plugin_checker",
-			"diagnose-script_extender_plugin_checker",
 			"scriptextenderpluginchecker"
 			})
 		.add_task<mo>({"modorganizer-form43_checker", "form43checker"})

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -124,6 +124,7 @@ void add_tasks()
 		.add_task<mo>({
 			"modorganizer-script_extender_plugin_checker",
 			"diagnose-script_extender_plugin_checker",
+			"scriptextenderpluginchecker"
 			})
 		.add_task<mo>({"modorganizer-form43_checker", "form43checker"})
 		.add_task<mo>({"modorganizer-preview_dds", "ddspreview"})


### PR DESCRIPTION
The slug of the translations is `ScriptExtenderPluginChecker` on Transifex to match the filename of the plugin, this just removes the `mob` warning about no matching task.