### PR TITLE
Builtin Qt translations

### DIFF
--- a/mob.ini
+++ b/mob.ini
@@ -143,6 +143,7 @@ install_translations =
 vs                   =
 qt_install           =
 qt_bin               =
+qt_translations      =
 pf_x86               =
 pf_x64               =
 temp_dir             =

--- a/src/core/conf.cpp
+++ b/src/core/conf.cpp
@@ -488,14 +488,15 @@ void resolve_paths()
 	set_path_if_empty("third_party", find_third_party_directory);
 	this_env::prepend_to_path(conf().path().third_party() / "bin");
 
-	set_path_if_empty("pf_x86",     find_program_files_x86);
-	set_path_if_empty("pf_x64",     find_program_files_x64);
-	set_path_if_empty("vs",         find_vs);
-	set_path_if_empty("qt_install", find_qt);
-	set_path_if_empty("temp_dir",   find_temp_dir);
-	set_path_if_empty("patches",    find_in_root("patches"));
-	set_path_if_empty("licenses",   find_in_root("licenses"));
-	set_path_if_empty("qt_bin",     qt::installation_path() / "bin");
+	set_path_if_empty("pf_x86",          find_program_files_x86);
+	set_path_if_empty("pf_x64",          find_program_files_x64);
+	set_path_if_empty("vs",              find_vs);
+	set_path_if_empty("qt_install",      find_qt);
+	set_path_if_empty("temp_dir",        find_temp_dir);
+	set_path_if_empty("patches",         find_in_root("patches"));
+	set_path_if_empty("licenses",        find_in_root("licenses"));
+	set_path_if_empty("qt_bin",          qt::installation_path() / "bin");
+	set_path_if_empty("qt_translations", qt::installation_path() / "translations");
 
 	// second, if any of these paths are relative, they use the second argument
 	// as the root; if they're empty, they combine the second and third

--- a/src/core/conf.h
+++ b/src/core/conf.h
@@ -220,6 +220,7 @@ public:
 	VALUE(vs);
 	VALUE(qt_install);
 	VALUE(qt_bin);
+	VALUE(qt_translations);
 
 	VALUE(pf_x86);
 	VALUE(pf_x64);

--- a/src/tasks/tasks.h
+++ b/src/tasks/tasks.h
@@ -627,6 +627,11 @@ public:
 			std::vector<fs::path> ts_files;
 
 			lang(std::string n);
+
+			// if `name` has an underscore, returns the part before and after
+			// it; if there is no underscore, first is `name`, second is empty
+			//
+			std::pair<std::string, std::string> split() const;
 		};
 
 		// a project that contains languages
@@ -653,6 +658,10 @@ public:
 		// any warnings that happened while walking the directories
 		//
 		const std::vector<std::string>& warnings() const;
+
+		// return a project by name
+		//
+		std::optional<project> find(std::string_view name) const;
 
 	private:
 		// translations directory
@@ -696,6 +705,11 @@ protected:
 	void do_clean(clean c) override;
 	void do_fetch() override;
 	void do_build_and_install() override;
+
+private:
+	// copy builtin qt .qm files
+	void copy_builtin_qt_translations(
+		const projects::project& organizer_project, const fs::path& dest);
 };
 
 


### PR DESCRIPTION
- Added `qt_translations` to paths in `mob.ini`, defaults to `$qt_install/translations`
- The `translations` task now copies builtin Qt `.qm` files
- Added error handling for missing `translations` directory, `directory_iterator` can throw

Fixes https://github.com/ModOrganizer2/modorganizer/issues/1420.