### PR TITLE
Generate archive for uibase library when releasing.

### DIFF
--- a/src/cmd/commands.h
+++ b/src/cmd/commands.h
@@ -310,6 +310,7 @@ public:
 	void make_bin();
 	void make_pdbs();
 	void make_src();
+	void make_uibase();
 	void make_installer();
 
 protected:
@@ -331,6 +332,7 @@ private:
 	bool bin_ = true;
 	bool src_ = true;
 	bool pdbs_ = true;
+	bool uibase_ = true;
 	bool installer_ = false;
 	std::string utf8out_;
 	fs::path out_;

--- a/src/cmd/release.cpp
+++ b/src/cmd/release.cpp
@@ -100,6 +100,27 @@ void release_command::make_src()
 		files, tasks::modorganizer::super_path(), out);
 }
 
+void release_command::make_uibase()
+{
+	const auto out = out_ / make_filename("uibase");
+	u8cout << "making uibase archive " << path_to_utf8(out) << "\n";
+
+	std::vector<fs::path> files;
+
+	if (!fs::exists(tasks::modorganizer::super_path()))
+	{
+		gcx().bail_out(context::generic,
+			"modorganizer super path not found: {}",
+			tasks::modorganizer::super_path());
+	}
+
+	op::archive_from_glob(gcx(),
+		tasks::modorganizer::super_path() / "uibase" / "src" / "*.h", out, {});
+	op::archive_from_glob(gcx(),
+		tasks::modorganizer::super_path() / "game_features" / "src" / "*.h", out, {});
+	op::archive_from_files(gcx(), { conf().path().install_libs() / "uibase.lib" }, conf().path().install_libs(), out);
+}
+
 void release_command::make_installer()
 {
 	const auto file = "Mod.Organizer-" + version_ + ".exe";
@@ -190,6 +211,11 @@ clipp::group release_command::do_group()
 				clipp::option("--src").set(src_, true) |
 				clipp::option("--no-src").set(src_, false)
 			) % "sets whether the source archive is created [default: yes]",
+
+			//(
+			//	clipp::option("--uibase").set(uibase_, true) |
+			//	clipp::option("--no-uibase").set(uibase_, false)
+			//) % "sets whether the uibase archive is created [default: yes]",
 
 			(
 				clipp::option("--inst").set(installer_, true) |
@@ -286,6 +312,9 @@ int release_command::do_devbuild()
 	if (src_)
 		make_src();
 
+	if (uibase_)
+		make_uibase();
+
 	if (installer_)
 		make_installer();
 
@@ -311,6 +340,7 @@ int release_command::do_official()
 	make_bin();
 	make_pdbs();
 	make_src();
+	make_uibase();
 	make_installer();
 
 	return 0;


### PR DESCRIPTION
When running `mob release`, will generate an archive `Mod.Organizer-X.Y.Z-uibase.7z` containing 

- the `uibase` headers
- the `game_features` headers
- the `uibase` library (`uibase.lib`)

The commented code for `clipp` is because this makes VS crash with an "out-of-heap" memory... Not sure why? I don't really have time to investigate right now, and it does not really hurt (creating the archive is instantaneous).