### PR TITLE
Change code page from 850 to 65001 for sip

### DIFF
--- a/src/tasks/sip.cpp
+++ b/src/tasks/sip.cpp
@@ -212,7 +212,7 @@ void sip::generate_header()
 	// by plugin_python
 	run_tool(process_runner(process()
 		.binary(sip_module_exe())
-		.chcp(850)
+		.chcp(65001)
 		.stdout_encoding(encodings::acp)
 		.stderr_encoding(encodings::acp)
 		.arg("--sip-h")


### PR DESCRIPTION
Some systems, like the Windows Server Core (tested with lts 2019), apparently don't have code page 850 and using `chcp 850` results in "Invalid code page". Sip is the only task that uses 850, all others either have none specified or use 65001 so swapping from 850 to 65001 fixes this problem.