### PR TITLE
Update README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -40,8 +40,8 @@
   - Desktop development with C++
   - Git for Windows (if you don't have git already installed)
   - .NET Framework 3.5 development tools
-  - .NET Framework 4.6 targeting pack
-  - .NET Framework 4.6.1 targeting pack and SDK
+  - .NET Framework 4.6 targeting pack (alternative: [Developer Pack](https://dotnet.microsoft.com/download/dotnet-framework/net46))
+  - .NET Framework 4.8 targeting pack and SDK (alternative: [Developer Pack](https://dotnet.microsoft.com/download/dotnet-framework/net48))
 - Start a shell
   - If you have git in your path, a regular cmd shell works.
   - If not, start the _x64 Native Tools Command Prompt for VS 2019_, it'll use Git for Windows installed above.


### PR DESCRIPTION
Remove .NET Framework 4.6.1 and add .NET Framework 4.8 which is required for `installer_omod`:

```
970.65  [installer_omod]  [msbuild] [stdout]       4>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(1216,5): error MSB3644: The reference assemblies for .NETFramework,Version=v4.8 were not found. To resolve this, install the Developer Pack (SDK/Targeting Pack) for this framework version or retarget your application. You can download .NET Framework Developer Packs at https://aka.ms/msbuild/developerpacks [C:\dev\modorganizer\build\modorganizer_super\installer_omod\vsbuild\dummy_cs_project.csproj]
970.78  [installer_omod]  [msbuild] [stdout]           C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(1216,5): error MSB3644: The reference assemblies for .NETFramework,Version=v4.8 were not found. To resolve this, install the Developer Pack (SDK/Targeting Pack) for this framework version or retarget your application. You can download .NET Framework Developer Packs at https://aka.ms/msbuild/developerpacks [C:\dev\modorganizer\build\modorganizer_super\installer_omod\vsbuild\dummy_cs_project.csproj]
970.80  [installer_omod]  [msbuild] [cmd]     msbuild failed, stderr was empty
970.80  [installer_omod]  [msbuild] [cmd]     msbuild returned 1 (bailing out)
970.81                                        installer_omod bailed out, interrupting all tasks
```