### PR TITLE
Updated README for 6.7.0

### DIFF
--- a/mob.ini
+++ b/mob.ini
@@ -117,7 +117,7 @@ qt             = 6.7.0
 qt_vs          = 2019
 zlib           = v1.3.1
 libbsarch      = 0.0.9
-usvfs          = qt6
+usvfs          = master
 explorerpp     = 1.4.0
 
 ss_paper_lad_6788      = 7.2

--- a/readme.md
+++ b/readme.md
@@ -90,8 +90,8 @@ aqt install-qt --outputdir "C:\Qt" windows desktop 6.7.0 win64_msvc2019_64 -m qt
 ```powershell
 mkdir C:\dev
 cd C:\dev
-bootstrap.bat
 git clone https://github.com/ModOrganizer2/mob
+./bootstrap.ps1
 mob -d C:\dev\modorganizer build
 ```
 - Once `mob` is finished, everything will be in `C:\dev\modorganizer`. Mod Organizer can be run from `install\bin\ModOrganizer.exe`. The Visual Studio solution for Mod Organizer itself is `build\modorganizer_super\modorganizer\vsbuild\organizer.sln`.

--- a/readme.md
+++ b/readme.md
@@ -52,11 +52,11 @@
 #### Using aqt
 - Open a terminal with administrative rights, and run
 ```powershell
-aqt install-qt --outputdir "C:\Qt" windows desktop 6.5.0 win64_msvc2019_64 -m qtwebengine qtimageformats qtpositioning qtserialport qtwebchannel qtwebsockets
+aqt install-qt --outputdir "C:\Qt" windows desktop 6.7.0 win64_msvc2019_64 -m qtwebengine qtimageformats qtpositioning qtserialport qtwebchannel qtwebsockets
 ```
 
 ### Qt - Manual installation
-- Install Qt 6.5.0 ([Installer](https://download.qt.io/official_releases/online_installers/qt-unified-windows-x64-online.exe)) and select these components:
+- Install Qt 6.7.0 ([Installer](https://download.qt.io/official_releases/online_installers/qt-unified-windows-x64-online.exe)) and select these components:
   - MSVC 2019 64-bit
   - Additional Libraries:
     - Qt WebEngine (display nexus pages)
@@ -90,6 +90,7 @@ aqt install-qt --outputdir "C:\Qt" windows desktop 6.5.0 win64_msvc2019_64 -m qt
 ```powershell
 mkdir C:\dev
 cd C:\dev
+bootstrap.bat
 git clone https://github.com/ModOrganizer2/mob
 mob -d C:\dev\modorganizer build
 ```


### PR DESCRIPTION
# Motivations
We recently merged Qt 6.7.0 as a dependency, so the readme should reflect that

# Modifications
- Update README Qt version references
- Add another step to getting mob setup
- Update mob.ini to point towards the master version of usfvs now that qt6 was merged 10 months ago