### PR TITLE
Remove option to use USVFS prebuilt.

### DIFF
--- a/mob.ini
+++ b/mob.ini
@@ -89,7 +89,6 @@ lz4     = true
 openssl = true
 pyqt    = true
 python  = true
-usvfs   = false
 
 [versions]
 vs             = 17

--- a/src/tasks/tasks.h
+++ b/src/tasks/tasks.h
@@ -646,21 +646,10 @@ namespace mob::tasks {
         void do_build_and_install() override;
 
     private:
-        void fetch_prebuilt();
         void fetch_from_source();
-        void build_and_install_prebuilt();
         void build_and_install_from_source();
 
-        void download_from_appveyor(arch a);
-        void copy_prebuilt(arch a);
-
         msbuild create_msbuild_tool(arch a, msbuild::ops o = msbuild::build) const;
-
-        std::vector<std::shared_ptr<downloader>>
-        create_appveyor_downloaders(arch a,
-                                    downloader::ops o = downloader::download) const;
-
-        std::string prebuilt_directory_name(arch a) const;
     };
 
     class zlib : public basic_task<zlib> {


### PR DESCRIPTION
This remove the possibility to use pre-built for USVFS.

I don't think anyone has ever used these, and the AppVeyor builds are currently failing. I should be able to switch USVFS build to Github action soon, but I do not want to bother uploading prebuilt. 

Since building USVFS is very fast, I don't see a reason to provide prebuilt anymore.