### PR TITLE
More flexibility to build Debug components

### DIFF
--- a/mob.ini
+++ b/mob.ini
@@ -22,13 +22,14 @@ super   = cmake_common modorganizer* githubpp
 plugins = check_fnis bsapacker bsa_extractor diagnose_basic installer_* plugin_python preview_base preview_bsa tool_* game_*
 
 [task]
-enabled     = true
-mo_org      = ModOrganizer2
-mo_branch   = master
-mo_fallback =
-no_pull     = false
-ignore_ts   = false
-revert_ts   = false
+enabled       = true
+mo_org        = ModOrganizer2
+mo_branch     = master
+mo_fallback   =
+no_pull       = false
+ignore_ts     = false
+revert_ts     = false
+configuration = RelWithDebInfo
 
 git_url_prefix = https://github.com/
 git_shallow    = true

--- a/mob.ini
+++ b/mob.ini
@@ -119,12 +119,6 @@ zlib           = v1.3.1
 libbsarch      = 0.0.9
 usvfs          = master
 explorerpp     = 1.4.0
-
-[build-types]
-libbsarch = release
-pyqt = release
-python = release
-
 ss_paper_lad_6788      = 7.2
 ss_paper_automata_6788 = 3.2
 ss_paper_mono_6788     = 3.2
@@ -134,6 +128,11 @@ ss_skyrim_trosski      = v1.1
 ss_starfield_trosski   = V1.11
 ss_fallout3_trosski    = v1.11
 ss_fallout4_trosski    = v1.11
+
+[build-types]
+libbsarch = release
+pyqt = release
+python = release
 
 [paths]
 third_party          =

--- a/mob.ini
+++ b/mob.ini
@@ -120,6 +120,11 @@ libbsarch      = 0.0.9
 usvfs          = master
 explorerpp     = 1.4.0
 
+[build-types]
+libbsarch = release
+pyqt = release
+python = release
+
 ss_paper_lad_6788      = 7.2
 ss_paper_automata_6788 = 3.2
 ss_paper_mono_6788     = 3.2

--- a/readme.md
+++ b/readme.md
@@ -68,7 +68,7 @@ aqt install-qt --outputdir "C:\Qt" windows desktop 6.7.0 win64_msvc2019_64 -m qt
   - Optional:
     - Qt Source Files
     - Qt Debug Files
-  
+
 ### Visual Studio
 - Install Visual Studio 2022 ([Installer](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=Community&channel=Release&version=VS2022&source=VSLandingPage&cid=2030&passive=false))
   - Desktop development with C++
@@ -141,9 +141,10 @@ Inside the INI file are `[sections]` and `key = value` pairs. The `[task]` secti
 ### `[task]`
 Options for individual tasks. Can be `[task_name:task]`, where `task_name` is the name of a task (see `mob list`) , `super` for all MO tasks or a glob like `installer_*`.
 
-| Option      | Type   | Description |
-| ---         | ---    | ---         |
-| `enabled`   | bool   | Whether this task is enabled. Disabled tasks are never built. When specifying task names with `mob build task1 task2...`, all tasks except those given are turned off. |
+| Option          | Type   | Description |
+| ---             | ---    | ---         |
+| `enabled`       | bool   | Whether this task is enabled. Disabled tasks are never built. When specifying task names with `mob build task1 task2...`, all tasks except those given are turned off. |
+| `configuration` | enum   | Which configuration to build, should be one of Debug, Release or RelWithDebInfo with RelWithDebInfo being the default.|
 
 #### Common git options
 Unless otherwise stated, applies to any task that is a git repo.

--- a/src/core/conf.h
+++ b/src/core/conf.h
@@ -211,7 +211,9 @@ namespace mob {
         conf_paths();
 
 #define VALUE(NAME)                                                                    \
-    fs::path NAME() const {return get(#NAME);                                          \
+    fs::path NAME() const                                                              \
+    {                                                                                  \
+        return get(#NAME);                                                             \
     }
 
         VALUE(third_party);

--- a/src/core/conf.h
+++ b/src/core/conf.h
@@ -237,7 +237,9 @@ namespace mob {
         conf_paths();
 
 #define VALUE(NAME)                                                                    \
-    fs::path NAME() const {return get(#NAME);                                          \
+    fs::path NAME() const                                                              \
+    {                                                                                  \
+        return get(#NAME);                                                             \
     }
 
         VALUE(third_party);

--- a/src/tasks/boost.cpp
+++ b/src/tasks/boost.cpp
@@ -218,23 +218,27 @@ namespace mob::tasks {
             bootstrap();
         }
 
-        // some libraries only need some variants, avoid building the unnecessary
-        // ones
+        // we do not need all variants of all components but since people should
+        // usually be using the pre-built, we can build everything without losing too
+        // much time and it is much easier to deal when mixing
+        //
+        // note: filesystem is only required by USVFS I think, so maybe think about
+        // removing it if we switch to std::filesystem in USVFS
+        //
+        clipp::arg_list components{"thread", "date_time", "filesystem", "locale",
+                                   "program_options"};
 
         // static link, static runtime, x64
-        do_b2({"thread", "date_time", "filesystem", "locale", "program_options"},
-              "static", "static", arch::x64);
+        do_b2(components, "static", "static", arch::x64);
 
         // static link, static runtime, x86, required by usvfs 32-bit
-        do_b2({"thread", "date_time", "filesystem", "locale"}, "static", "static",
-              arch::x86);
+        do_b2(components, "static", "static", arch::x86);
 
         // static link, shared runtime, x64
-        do_b2({"thread", "date_time", "locale", "program_options"}, "static", "shared",
-              arch::x64);
+        do_b2(components, "static", "shared", arch::x64);
 
         // shared link, shared runtime, x64
-        do_b2({"thread", "date_time", "atomic"}, "shared", "shared", arch::x64);
+        do_b2(components, "shared", "shared", arch::x64);
     }
 
     void boost::do_b2(const std::vector<std::string>& components,

--- a/src/tasks/boost.cpp
+++ b/src/tasks/boost.cpp
@@ -231,8 +231,9 @@ namespace mob::tasks {
         // static link, static runtime, x64
         do_b2(components, "static", "static", arch::x64);
 
-        // static link, static runtime, x86, required by usvfs 32-bit
+        // static link, static/shared runtime, x86, required by usvfs 32-bit
         do_b2(components, "static", "static", arch::x86);
+        do_b2(components, "static", "shared", arch::x86);
 
         // static link, shared runtime, x64
         do_b2(components, "static", "shared", arch::x64);

--- a/src/tasks/gtest.cpp
+++ b/src/tasks/gtest.cpp
@@ -5,8 +5,7 @@ namespace mob::tasks {
 
     namespace {
 
-        cmake create_cmake_tool(arch a, const std::string& config,
-                                cmake::ops o = cmake::generate)
+        cmake create_cmake_tool(arch a, config config, cmake::ops o = cmake::generate)
         {
             return std::move(cmake(o)
                                  .generator(cmake::vs)
@@ -17,12 +16,12 @@ namespace mob::tasks {
                                  .root(gtest::source_path()));
         }
 
-        msbuild create_msbuild_tool(arch a, std::string const& config,
+        msbuild create_msbuild_tool(arch a, config config,
                                     msbuild::ops o = msbuild::build)
         {
             const fs::path build_path = create_cmake_tool(a, config).build_path();
 
-            return std::move(msbuild(o).architecture(a).config(config).solution(
+            return std::move(msbuild(o).architecture(a).configuration(config).solution(
                 build_path / "INSTALL.vcxproj"));
         }
 
@@ -45,9 +44,10 @@ namespace mob::tasks {
         return conf().path().build() / "googletest";
     }
 
-    fs::path gtest::build_path(arch a, const std::string& c)
+    fs::path gtest::build_path(arch a, config c)
     {
-        return source_path() / "build" / (a == arch::x64 ? "x64" : "Win32") / c;
+        return source_path() / "build" / (a == arch::x64 ? "x64" : "Win32") /
+               msbuild::configuration_name(c);
     }
 
     void gtest::do_clean(clean c)
@@ -58,15 +58,15 @@ namespace mob::tasks {
         }
 
         if (is_set(c, clean::reconfigure)) {
-            run_tool(create_cmake_tool(arch::x86, "Release", cmake::clean));
-            run_tool(create_cmake_tool(arch::x64, "Release", cmake::clean));
+            run_tool(create_cmake_tool(arch::x86, config::release, cmake::clean));
+            run_tool(create_cmake_tool(arch::x64, config::release, cmake::clean));
         }
 
         if (is_set(c, clean::rebuild)) {
-            run_tool(create_msbuild_tool(arch::x86, "Release", msbuild::clean));
-            run_tool(create_msbuild_tool(arch::x86, "Debug", msbuild::clean));
-            run_tool(create_msbuild_tool(arch::x64, "Release", msbuild::clean));
-            run_tool(create_msbuild_tool(arch::x64, "Debug", msbuild::clean));
+            run_tool(create_msbuild_tool(arch::x86, config::release, msbuild::clean));
+            run_tool(create_msbuild_tool(arch::x86, config::debug, msbuild::clean));
+            run_tool(create_msbuild_tool(arch::x64, config::release, msbuild::clean));
+            run_tool(create_msbuild_tool(arch::x64, config::debug, msbuild::clean));
         }
     }
 
@@ -85,19 +85,19 @@ namespace mob::tasks {
 
         parallel({{"gtest64",
                    [&] {
-                       run_tool(create_cmake_tool(arch::x64, "Release"));
-                       run_tool(create_msbuild_tool(arch::x64, "Release"));
+                       run_tool(create_cmake_tool(arch::x64, config::release));
+                       run_tool(create_msbuild_tool(arch::x64, config::release));
 
-                       run_tool(create_cmake_tool(arch::x64, "Debug"));
-                       run_tool(create_msbuild_tool(arch::x64, "Debug"));
+                       run_tool(create_cmake_tool(arch::x64, config::debug));
+                       run_tool(create_msbuild_tool(arch::x64, config::debug));
                    }},
 
                   {"gtest32", [&] {
-                       run_tool(create_cmake_tool(arch::x86, "Release"));
-                       run_tool(create_msbuild_tool(arch::x86, "Release"));
+                       run_tool(create_cmake_tool(arch::x86, config::release));
+                       run_tool(create_msbuild_tool(arch::x86, config::release));
 
-                       run_tool(create_cmake_tool(arch::x86, "Debug"));
-                       run_tool(create_msbuild_tool(arch::x86, "Debug"));
+                       run_tool(create_cmake_tool(arch::x86, config::debug));
+                       run_tool(create_msbuild_tool(arch::x86, config::debug));
                    }}});
     }
 

--- a/src/tasks/gtest.cpp
+++ b/src/tasks/gtest.cpp
@@ -5,25 +5,25 @@ namespace mob::tasks {
 
     namespace {
 
-        cmake create_cmake_tool(arch a, cmake::ops o = cmake::generate)
+        cmake create_cmake_tool(arch a, const std::string& config,
+                                cmake::ops o = cmake::generate)
         {
-            const std::string build_dir = (a == arch::x64 ? "build" : "build_32");
-
             return std::move(cmake(o)
                                  .generator(cmake::vs)
                                  .architecture(a)
                                  .arg("-Wno-deprecated")
                                  .arg("-Dgtest_force_shared_crt=ON")
-                                 .prefix(gtest::source_path() / build_dir)
+                                 .prefix(gtest::build_path(a, config))
                                  .root(gtest::source_path()));
         }
 
-        msbuild create_msbuild_tool(arch a, msbuild::ops o = msbuild::build)
+        msbuild create_msbuild_tool(arch a, std::string const& config,
+                                    msbuild::ops o = msbuild::build)
         {
-            const fs::path build_path = create_cmake_tool(a).build_path();
+            const fs::path build_path = create_cmake_tool(a, config).build_path();
 
-            return std::move(
-                msbuild(o).architecture(a).solution(build_path / "INSTALL.vcxproj"));
+            return std::move(msbuild(o).architecture(a).config(config).solution(
+                build_path / "INSTALL.vcxproj"));
         }
 
     }  // namespace
@@ -45,6 +45,11 @@ namespace mob::tasks {
         return conf().path().build() / "googletest";
     }
 
+    fs::path gtest::build_path(arch a, const std::string& c)
+    {
+        return source_path() / "build" / (a == arch::x64 ? "x64" : "Win32") / c;
+    }
+
     void gtest::do_clean(clean c)
     {
         if (is_set(c, clean::reclone)) {
@@ -53,13 +58,15 @@ namespace mob::tasks {
         }
 
         if (is_set(c, clean::reconfigure)) {
-            run_tool(create_cmake_tool(arch::x86, cmake::clean));
-            run_tool(create_cmake_tool(arch::x64, cmake::clean));
+            run_tool(create_cmake_tool(arch::x86, "Release", cmake::clean));
+            run_tool(create_cmake_tool(arch::x64, "Release", cmake::clean));
         }
 
         if (is_set(c, clean::rebuild)) {
-            run_tool(create_msbuild_tool(arch::x86, msbuild::clean));
-            run_tool(create_msbuild_tool(arch::x64, msbuild::clean));
+            run_tool(create_msbuild_tool(arch::x86, "Release", msbuild::clean));
+            run_tool(create_msbuild_tool(arch::x86, "Debug", msbuild::clean));
+            run_tool(create_msbuild_tool(arch::x64, "Release", msbuild::clean));
+            run_tool(create_msbuild_tool(arch::x64, "Debug", msbuild::clean));
         }
     }
 
@@ -73,15 +80,24 @@ namespace mob::tasks {
 
     void gtest::do_build_and_install()
     {
+        op::create_directories(cx(), gtest::build_path(arch::x64).parent_path());
+        op::create_directories(cx(), gtest::build_path(arch::x86).parent_path());
+
         parallel({{"gtest64",
                    [&] {
-                       run_tool(create_cmake_tool(arch::x64));
-                       run_tool(create_msbuild_tool(arch::x64));
+                       run_tool(create_cmake_tool(arch::x64, "Release"));
+                       run_tool(create_msbuild_tool(arch::x64, "Release"));
+
+                       run_tool(create_cmake_tool(arch::x64, "Debug"));
+                       run_tool(create_msbuild_tool(arch::x64, "Debug"));
                    }},
 
                   {"gtest32", [&] {
-                       run_tool(create_cmake_tool(arch::x86));
-                       run_tool(create_msbuild_tool(arch::x86));
+                       run_tool(create_cmake_tool(arch::x86, "Release"));
+                       run_tool(create_msbuild_tool(arch::x86, "Release"));
+
+                       run_tool(create_cmake_tool(arch::x86, "Debug"));
+                       run_tool(create_msbuild_tool(arch::x86, "Debug"));
                    }}});
     }
 

--- a/src/tasks/libbsarch.cpp
+++ b/src/tasks/libbsarch.cpp
@@ -7,7 +7,9 @@ namespace mob::tasks {
 
         std::string dir_name()
         {
-            return "libbsarch-" + libbsarch::version() + "-release-x64";
+            return "libbsarch-" + libbsarch::version() + "-" +
+                   (libbsarch::build_type() == config::debug ? "debug" : "release") +
+                   "-x64";
         }
 
         url source_url()
@@ -23,6 +25,11 @@ namespace mob::tasks {
     std::string libbsarch::version()
     {
         return conf().version().get("libbsarch");
+    }
+
+    config libbsarch::build_type()
+    {
+        return conf().build_types().get("libbsarch");
     }
 
     bool libbsarch::prebuilt()

--- a/src/tasks/modorganizer.cpp
+++ b/src/tasks/modorganizer.cpp
@@ -220,7 +220,7 @@ namespace mob::tasks {
                              .def("SEVENZ_ROOT", sevenz::source_path())
                              .def("LIBBSARCH_ROOT", libbsarch::source_path())
                              .def("BOOST_DI_ROOT", boost_di::source_path())
-                             .def("GTEST_ROOT", gtest::source_path())
+                             .def("GTEST_ROOT", gtest::build_path())
                              .def("OPENSSL_ROOT_DIR", openssl::source_path())
                              .root(root));
     }

--- a/src/tasks/modorganizer.cpp
+++ b/src/tasks/modorganizer.cpp
@@ -200,36 +200,40 @@ namespace mob::tasks {
 
     cmake modorganizer::create_cmake_tool(cmake::ops o)
     {
-        return create_cmake_tool(source_path(), o);
+        return create_cmake_tool(source_path(), o, task_conf().configuration());
     }
 
-    cmake modorganizer::create_cmake_tool(const fs::path& root, cmake::ops o)
+    cmake modorganizer::create_cmake_tool(const fs::path& root, cmake::ops o, config c)
     {
-        return std::move(cmake(o)
-                             .generator(cmake::vs)
-                             .def("CMAKE_INSTALL_PREFIX:PATH", conf().path().install())
-                             .def("DEPENDENCIES_DIR", conf().path().build())
-                             .def("BOOST_ROOT", boost::source_path())
-                             .def("BOOST_LIBRARYDIR", boost::lib_path(arch::x64))
-                             .def("SPDLOG_ROOT", spdlog::source_path())
-                             .def("LOOT_PATH", libloot::source_path())
-                             .def("LZ4_ROOT", lz4::source_path())
-                             .def("QT_ROOT", qt::installation_path())
-                             .def("ZLIB_ROOT", zlib::source_path())
-                             .def("PYTHON_ROOT", python::source_path())
-                             .def("SEVENZ_ROOT", sevenz::source_path())
-                             .def("LIBBSARCH_ROOT", libbsarch::source_path())
-                             .def("BOOST_DI_ROOT", boost_di::source_path())
-                             .def("GTEST_ROOT", gtest::build_path())
-                             .def("OPENSSL_ROOT_DIR", openssl::source_path())
-                             .root(root));
+        return std::move(
+            cmake(o)
+                .generator(cmake::vs)
+                .def("CMAKE_INSTALL_PREFIX:PATH", conf().path().install())
+                .def("DEPENDENCIES_DIR", conf().path().build())
+                .def("BOOST_ROOT", boost::source_path())
+                .def("BOOST_LIBRARYDIR", boost::lib_path(arch::x64))
+                .def("SPDLOG_ROOT", spdlog::source_path())
+                .def("LOOT_PATH", libloot::source_path())
+                .def("LZ4_ROOT", lz4::source_path())
+                .def("QT_ROOT", qt::installation_path())
+                .def("ZLIB_ROOT", zlib::source_path())
+                .def("PYTHON_ROOT", python::source_path())
+                .def("SEVENZ_ROOT", sevenz::source_path())
+                .def("LIBBSARCH_ROOT", libbsarch::source_path())
+                .def("BOOST_DI_ROOT", boost_di::source_path())
+                // gtest has no RelWithDebInfo, so simply use Debug/Release
+                .def("GTEST_ROOT",
+                     gtest::build_path(arch::x64, c == config::debug ? config::debug
+                                                                     : config::release))
+                .def("OPENSSL_ROOT_DIR", openssl::source_path())
+                .root(root));
     }
 
     msbuild modorganizer::create_msbuild_tool(msbuild::ops o)
     {
         return std::move(msbuild(o)
                              .solution(project_file_path())
-                             .config("RelWithDebInfo")
+                             .configuration(task_conf().configuration())
                              .architecture(arch::x64));
     }
 

--- a/src/tasks/pyqt.cpp
+++ b/src/tasks/pyqt.cpp
@@ -171,7 +171,24 @@ namespace mob::tasks {
     void pyqt::build_and_install_from_source()
     {
         // use pip to install the pyqt builder
-        run_tool(pip(pip::install).package("PyQt-builder").version(builder_version()));
+        if (python::build_type() == config::debug) {
+            // PyQt-builder has sip as a dependency, so installing it directly will
+            // replace the sip we have installed manually, but the installed sip will
+            // not work (see comment in sip::build() for details)
+            //
+            // the workaround is to install the dependencies manually (only packaging),
+            // and then use a --no-dependencies install with pip
+            //
+            run_tool(pip(pip::install).package("packaging"));
+            run_tool(pip(pip::install)
+                         .package("PyQt-builder")
+                         .no_dependencies()
+                         .version(builder_version()));
+        }
+        else {
+            run_tool(
+                pip(pip::install).package("PyQt-builder").version(builder_version()));
+        }
 
         // patch for builder.py
         run_tool(patcher()

--- a/src/tasks/pyqt.cpp
+++ b/src/tasks/pyqt.cpp
@@ -47,7 +47,9 @@ namespace mob::tasks {
 
         url prebuilt_url()
         {
-            return make_prebuilt_url("PyQt6_gpl-prebuilt-" + pyqt::version() + ".7z");
+            return make_prebuilt_url(
+                "PyQt6_gpl-prebuilt-" + pyqt::version() +
+                (pyqt::build_type() == config::debug ? "-debug" : "") + ".7z");
         }
 
         // file created by sip-module.exe

--- a/src/tasks/pyqt.cpp
+++ b/src/tasks/pyqt.cpp
@@ -234,30 +234,29 @@ namespace mob::tasks {
             // here instead
             op::delete_directory(cx(), source_path() / "build", op::optional);
 
-            auto p = sip::sip_install_process()
-                         .arg("--confirm-license")
-                         .arg("--verbose", process::log_trace)
-                         .arg("--pep484-pyi")
-                         .arg("--link-full-dll")
-                         .arg("--build-dir", build_path())
-                         .cwd(source_path())
-                         .env(pyqt_env);
-
-            if (build_type() == config::debug) {
-                p.arg("--debug")
-                    // the distinfo generation currently fails with debug mode
-                    .arg("--no-distinfo");
-            }
-
             // build modules
-            run_tool(process_runner(p));
+            run_tool(process_runner(process()
+                                        .binary(sip::sip_install_exe())
+                                        .arg("--confirm-license")
+                                        .arg("--verbose", process::log_trace)
+                                        .arg("--pep484-pyi")
+                                        .arg("--link-full-dll")
+                                        .arg("--build-dir", build_path())
+                                        //			.arg("--enable",
+                                        //"pylupdate")  // these are not in modules so
+                                        // they .arg("--enable", "pyrcc")      // don't
+                                        // get copied below
+                                        // .args(zip(repeat("--enable"), modules()))
+                                        .cwd(source_path())
+                                        .env(pyqt_env)));
 
             // done, create the bypass file
             built_bypass.create();
         }
 
         // generate the PyQt6_sip-XX.tar.gz file
-        run_tool(process_runner(sip::sip_module_process()
+        run_tool(process_runner(process()
+                                    .binary(sip::sip_module_exe())
                                     .arg("--sdist")
                                     .arg(pyqt_sip_module_name())
                                     .cwd(conf().path().cache())

--- a/src/tasks/python.cpp
+++ b/src/tasks/python.cpp
@@ -30,7 +30,9 @@ namespace mob::tasks {
 
         url prebuilt_url()
         {
-            return make_prebuilt_url("python-prebuilt-" + version_without_v() + ".7z");
+            return make_prebuilt_url(
+                "python-prebuilt-" + version_without_v() +
+                (python::build_type() == config::debug ? "-debug" : "") + ".7z");
         }
 
         fs::path solution_file()

--- a/src/tasks/python.cpp
+++ b/src/tasks/python.cpp
@@ -89,6 +89,11 @@ namespace mob::tasks {
         return source_path() / "PCBuild" / "amd64";
     }
 
+    config python::build_type()
+    {
+        return conf().build_types().get("python");
+    }
+
     void python::do_clean(clean c)
     {
         if (prebuilt()) {
@@ -190,16 +195,22 @@ namespace mob::tasks {
 
         const auto bat = source_path() / "python.bat";
 
+        auto p = process()
+                     .binary(bat)
+                     .arg(fs::path("PC/layout"))
+                     .arg("--source", source_path())
+                     .arg("--build", build_path())
+                     .arg("--temp", (build_path() / "pythoncore_temp"))
+                     .arg("--copy", (build_path() / "pythoncore"))
+                     .arg("--preset-embed")
+                     .cwd(source_path());
+
+        if (build_type() == config::debug) {
+            p = p.arg("--debug");
+        }
+
         // package libs into pythonXX.zip
-        run_tool(process_runner(process()
-                                    .binary(bat)
-                                    .arg(fs::path("PC/layout"))
-                                    .arg("--source", source_path())
-                                    .arg("--build", build_path())
-                                    .arg("--temp", (build_path() / "pythoncore_temp"))
-                                    .arg("--copy", (build_path() / "pythoncore"))
-                                    .arg("--preset-embed")
-                                    .cwd(source_path())));
+        run_tool(process_runner(p));
     }
 
     void python::copy_files()
@@ -210,7 +221,9 @@ namespace mob::tasks {
 
         // pdbs
         op::copy_file_to_dir_if_better(
-            cx(), build_path() / ("python" + version_for_dll() + ".pdb"),
+            cx(),
+            build_path() / ("python" + version_for_dll() +
+                            (build_type() == config::debug ? "_d" : "") + ".pdb"),
             conf().path().install_pdbs());
 
         // dlls and python libraries are installed by the python plugin
@@ -229,6 +242,7 @@ namespace mob::tasks {
                 .solution(solution_file())
                 .targets({"python", "pythonw", "python3dll", "select", "pyexpat",
                           "unicodedata", "_queue", "_bz2", "_ssl", "_overlapped"})
+                .configuration(build_type())
                 .properties(
                     {"bz2Dir=" + path_to_utf8(bzip2::source_path()),
                      "zlibDir=" + path_to_utf8(zlib::source_path()),
@@ -238,7 +252,8 @@ namespace mob::tasks {
 
     fs::path python::python_exe()
     {
-        return build_path() / "python.exe";
+        return build_path() /
+               (build_type() == config::debug ? "python_d.exe" : "python.exe");
     }
 
     fs::path python::include_path()

--- a/src/tasks/sip.cpp
+++ b/src/tasks/sip.cpp
@@ -62,14 +62,14 @@ namespace mob::tasks {
         return conf().path().build() / ("sip-" + version());
     }
 
-    process sip::sip_module_process()
+    fs::path sip::sip_module_exe()
     {
-        return process().binary(python::scripts_path() / "sip-module.exe");
+        return python::scripts_path() / "sip-module.exe";
     }
 
-    process sip::sip_install_process()
+    fs::path sip::sip_install_exe()
     {
-        return process().binary(python::scripts_path() / "sip-install.exe");
+        return python::scripts_path() / "sip-install.exe";
     }
 
     fs::path sip::module_source_path()
@@ -193,7 +193,8 @@ namespace mob::tasks {
     {
         // generate sip.h, will be copied to python's include directory, used
         // by plugin_python
-        run_tool(process_runner(sip_module_process()
+        run_tool(process_runner(process()
+                                    .binary(sip_module_exe())
                                     .chcp(65001)
                                     .stdout_encoding(encodings::acp)
                                     .stderr_encoding(encodings::acp)

--- a/src/tasks/sip.cpp
+++ b/src/tasks/sip.cpp
@@ -144,6 +144,7 @@ namespace mob::tasks {
             // if Python is build in debug mode, fall back to old setup.py because pip
             // install seems to generated broken script wrapper that point to a
             // non-existing python.exe instead of python_d.exe
+            run_tool(pip(pip::install).package("setuptools"));
             run_tool(mob::python().root(source_path()).arg("setup.py").arg("install"));
         }
         else {

--- a/src/tasks/tasks.h
+++ b/src/tasks/tasks.h
@@ -486,8 +486,8 @@ namespace mob::tasks {
         static bool prebuilt();
 
         static fs::path source_path();
-        static process sip_module_process();
-        static process sip_install_process();
+        static fs::path sip_module_exe();
+        static fs::path sip_install_exe();
         static fs::path module_source_path();
 
     protected:

--- a/src/tasks/tasks.h
+++ b/src/tasks/tasks.h
@@ -97,8 +97,7 @@ namespace mob::tasks {
         static std::string version();
         static bool prebuilt();
         static fs::path source_path();
-        static fs::path build_path(arch arch                 = arch::x64,
-                                   const std::string& config = "Release");
+        static fs::path build_path(arch = arch::x64, config = config::release);
 
     protected:
         void do_clean(clean c) override;
@@ -199,7 +198,8 @@ namespace mob::tasks {
         // projects, used internally, but also by the cmake command
         //
         static cmake create_cmake_tool(const fs::path& root,
-                                       cmake::ops o = cmake::generate);
+                                       cmake::ops o  = cmake::generate,
+                                       config config = config::relwithdebinfo);
 
         // flags for some MO projects
         enum flags {
@@ -651,7 +651,8 @@ namespace mob::tasks {
         void fetch_from_source();
         void build_and_install_from_source();
 
-        msbuild create_msbuild_tool(arch a, msbuild::ops o = msbuild::build) const;
+        msbuild create_msbuild_tool(arch, msbuild::ops = msbuild::build,
+                                    config = config::release) const;
     };
 
     class zlib : public basic_task<zlib> {

--- a/src/tasks/tasks.h
+++ b/src/tasks/tasks.h
@@ -97,6 +97,8 @@ namespace mob::tasks {
         static std::string version();
         static bool prebuilt();
         static fs::path source_path();
+        static fs::path build_path(arch arch                 = arch::x64,
+                                   const std::string& config = "Release");
 
     protected:
         void do_clean(clean c) override;

--- a/src/tasks/tasks.h
+++ b/src/tasks/tasks.h
@@ -124,6 +124,7 @@ namespace mob::tasks {
         libbsarch();
 
         static std::string version();
+        static config build_type();
         static bool prebuilt();
         static fs::path source_path();
 
@@ -362,6 +363,7 @@ namespace mob::tasks {
 
         static fs::path source_path();
         static fs::path build_path();
+        static config build_type();
 
         // "PyQt5.sip", used both in pyqt and sip
         //
@@ -420,6 +422,10 @@ namespace mob::tasks {
         // build/python-XX/Lib/site-packages
         //
         static fs::path site_packages_path();
+
+        // configuration to build
+        //
+        static config build_type();
 
     protected:
         void do_clean(clean c) override;
@@ -480,8 +486,8 @@ namespace mob::tasks {
         static bool prebuilt();
 
         static fs::path source_path();
-        static fs::path sip_module_exe();
-        static fs::path sip_install_exe();
+        static process sip_module_process();
+        static process sip_install_process();
         static fs::path module_source_path();
 
     protected:

--- a/src/tasks/usvfs.cpp
+++ b/src/tasks/usvfs.cpp
@@ -42,8 +42,10 @@ namespace mob::tasks {
 
         if (is_set(c, clean::rebuild)) {
             // msbuild clean
-            run_tool(create_msbuild_tool(arch::x86, msbuild::clean));
-            run_tool(create_msbuild_tool(arch::x64, msbuild::clean));
+            run_tool(create_msbuild_tool(arch::x86, msbuild::clean,
+                                         task_conf().configuration()));
+            run_tool(create_msbuild_tool(arch::x64, msbuild::clean,
+                                         task_conf().configuration()));
         }
     }
 
@@ -71,7 +73,7 @@ namespace mob::tasks {
         run_tool(create_msbuild_tool(arch::x64));
     }
 
-    msbuild usvfs::create_msbuild_tool(arch a, msbuild::ops o) const
+    msbuild usvfs::create_msbuild_tool(arch a, msbuild::ops o, config c) const
     {
         // usvfs doesn't use "Win32" for 32-bit, it uses "x86"
         //
@@ -90,6 +92,7 @@ namespace mob::tasks {
         return std::move(
             msbuild(o)
                 .platform(plat)
+                .configuration(c)
                 .targets({"usvfs_proxy"})
                 .solution(source_path() / "vsbuild" / "usvfs.sln")
                 .env(env::vs(a)

--- a/src/tools/cmake.cpp
+++ b/src/tools/cmake.cpp
@@ -129,7 +129,7 @@ namespace mob {
                      .binary(binary())
                      .arg("-DCMAKE_BUILD_TYPE=Release")
                      .arg("-DCMAKE_INSTALL_MESSAGE=" +
-                          conf().cmake().install_message().value())
+                          conf_cmake::to_string(conf().cmake().install_message()))
                      .arg("--log-level=ERROR")
                      .arg("--no-warn-unused-cli");
 

--- a/src/tools/cmake.h
+++ b/src/tools/cmake.h
@@ -14,23 +14,25 @@ namespace mob {
 
         // type of build files generated
         //
-        enum generators {
+        enum class generators {
             // generates build files for visual studio
             vs = 0x01,
 
             // generates build files for jom/nmake
             jom = 0x02
         };
+        using enum generators;
 
         // what run() will do
         //
-        enum ops {
+        enum class ops {
             // generates the build files
             generate = 1,
 
             // cleans the build files so they're regenerated from scratch
             clean
         };
+        using enum ops;
 
         cmake(ops o = generate);
 

--- a/src/tools/msbuild.cpp
+++ b/src/tools/msbuild.cpp
@@ -7,14 +7,28 @@
 namespace mob {
 
     msbuild::msbuild(ops o)
-        : basic_process_runner("msbuild"), op_(o), config_("Release"), arch_(arch::def),
-          flags_(noflags)
+        : basic_process_runner("msbuild"), op_(o), config_(config::release),
+          arch_(arch::def), flags_(noflags)
     {
     }
 
     fs::path msbuild::binary()
     {
         return conf().tool().get("msbuild");
+    }
+
+    std::string msbuild::configuration_name(config c)
+    {
+        switch (c) {
+        case config::debug:
+            return "Debug";
+        case config::release:
+            return "Release";
+        case config::relwithdebinfo:
+            [[fallthrough]];
+        default:
+            return "RelWithDebInfo";
+        }
     }
 
     msbuild& msbuild::solution(const fs::path& sln)
@@ -35,9 +49,9 @@ namespace mob {
         return *this;
     }
 
-    msbuild& msbuild::config(const std::string& s)
+    msbuild& msbuild::configuration(config c)
     {
-        config_ = s;
+        config_ = c;
         return *this;
     }
 
@@ -151,7 +165,7 @@ namespace mob {
                 .arg("-property:EnforceProcessCountAcrossBuilds=true");
         }
 
-        p.arg("-property:Configuration=", config_, process::quote)
+        p.arg("-property:Configuration=", configuration_name(config_), process::quote)
             .arg("-property:PlatformToolset=" + toolset)
             .arg("-property:WindowsTargetPlatformVersion=" + vs::sdk())
             .arg("-property:Platform=", platform_property(), process::quote)

--- a/src/tools/msbuild.h
+++ b/src/tools/msbuild.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#include "../core/conf.h"
 #include "../core/env.h"
+#include "cmake.h"
 
 namespace mob {
 
@@ -14,11 +16,17 @@ namespace mob {
         //
         static fs::path binary();
 
-        enum flags_t { noflags = 0x00, single_job = 0x01, allow_failure = 0x02 };
+        // retrieve the name of the configuration for the given config
+        //
+        static std::string configuration_name(config c);
+
+        enum class flags_t { noflags = 0x00, single_job = 0x01, allow_failure = 0x02 };
+        using enum flags_t;
 
         // what run() should do
         //
-        enum ops { build = 1, clean };
+        enum class ops { build = 1, clean };
+        using enum ops;
 
         msbuild(ops o = build);
 
@@ -36,7 +44,7 @@ namespace mob {
 
         // sets "-property:Configuration=s"
         //
-        msbuild& config(const std::string& s);
+        msbuild& configuration(config config);
 
         // sets "-property:Platform=s"; if not set, uses architecture() to figure
         // it out
@@ -69,7 +77,7 @@ namespace mob {
         fs::path sln_;
         std::vector<std::string> targets_;
         std::vector<std::string> props_;
-        std::string config_;
+        config config_;
         std::string platform_;
         arch arch_;
         flags_t flags_;

--- a/src/tools/python.cpp
+++ b/src/tools/python.cpp
@@ -49,7 +49,7 @@ namespace mob {
         execute_and_join(p);
     }
 
-    pip::pip(ops op) : basic_process_runner("pip"), op_(op) {}
+    pip::pip(ops op) : basic_process_runner("pip"), op_(op), no_deps_{false} {}
 
     pip& pip::package(const std::string& s)
     {
@@ -66,6 +66,12 @@ namespace mob {
     pip& pip::file(const fs::path& p)
     {
         file_ = p;
+        return *this;
+    }
+
+    pip& pip::no_dependencies()
+    {
+        no_deps_ = true;
         return *this;
     }
 
@@ -141,10 +147,20 @@ namespace mob {
                      .arg("--no-warn-script-location")
                      .arg("--disable-pip-version-check");
 
-        if (!package_.empty())
-            p.arg(package_ + "==" + version_);
+        if (!package_.empty()) {
+            if (version_.empty()) {
+                p.arg(package_);
+            }
+            else {
+                p.arg(package_ + "==" + version_);
+            }
+        }
         else if (!file_.empty())
             p.arg(file_);
+
+        if (no_deps_) {
+            p.arg("--no-dependencies");
+        }
 
         p.env(this_env::get().set("PYTHONUTF8", "1"));
 

--- a/src/tools/tools.h
+++ b/src/tools/tools.h
@@ -703,6 +703,10 @@ namespace mob {
         pip& version(const std::string& s);
         pip& file(const fs::path& p);
 
+        // do not install dependencies for the package
+        //
+        pip& no_dependencies();
+
     protected:
         // runs pip
         //
@@ -716,6 +720,9 @@ namespace mob {
         std::string package_;
         std::string version_;
         fs::path file_;
+
+        // no depndencies
+        bool no_deps_;
 
         // runs `-m ensurepip`, then upgrades pip
         //

--- a/src/utility.h
+++ b/src/utility.h
@@ -46,6 +46,8 @@ namespace mob {
         def = x64
     };
 
+    enum class config { debug, relwithdebinfo, release };
+
     class url;
 
     // returns a url for a prebuilt binary having the given filename; prebuilts are


### PR DESCRIPTION
The goal of this PR is to:

* Make it easier to build USVFS Release tests (ReleaseTest configuration). Currently, it's kind of annoying because USVFS is build with `/MT` but GoogleTest with `/MD` (due to `gtest_force_shared_crt` in `mob`). Trying to build the test configuration of USVFS with `/MD` instead of `/MT` then throws issue with some missing boost components, especially for x86. The fix for this is to move the `ReleaseTest` configuration of USVFS to `/MD` (the `Release` configuration will be untouched) and to add the missing boost components.
* Make it easier to build USVFS and other libraries with tests in Debug mode. Currently it is not possible (without rebuilding googletest manually) because the Debug libraries of GoogleTest are not built. The fix for this is to build the Debug and Release configuration for GoogleTest. For USVFS, direct path to the appropriate build folder are added. Other components will still use `GTEST_ROOT`.
* Make it possible to build components in Debug/Release mode through `mob` (instead of RelWithDebInfo).

The following components support debug mode:

- `libbsarch` - Since `libbsarch` is not built by `mob`, this only changes the archive that is downloaded.
- `python` - This build Python in debug mode. Some changes have been made to `plugin_python` to match the changes.
- `pyqt` - This build PyQt in debug mode, but requires Python in debug mode.

PyQt debug build is a mess, so there are many "workaround", but I made sure to not modify the release path.