### PR TITLE
Update readme.md for Qt 6.7.1, fix quick start commands

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,10 +26,10 @@
 
 ## Quick start
 ```powershell
-> git clone https://github.com/ModOrganizer2/mob
-> cd mob
-> bootstrap
-> mob -d c:\somewhere build
+git clone https://github.com/ModOrganizer2/mob
+cd mob
+./bootstrap
+mob -d c:\somewhere build
 ```
 
 ## Extended start
@@ -52,11 +52,11 @@
 #### Using aqt
 - Open a terminal with administrative rights, and run
 ```powershell
-aqt install-qt --outputdir "C:\Qt" windows desktop 6.7.0 win64_msvc2019_64 -m qtwebengine qtimageformats qtpositioning qtserialport qtwebchannel qtwebsockets
+aqt install-qt --outputdir "C:\Qt" windows desktop 6.7.1 win64_msvc2019_64 -m qtwebengine qtimageformats qtpositioning qtserialport qtwebchannel qtwebsockets
 ```
 
 ### Qt - Manual installation
-- Install Qt 6.7.0 ([Installer](https://download.qt.io/official_releases/online_installers/qt-unified-windows-x64-online.exe)) and select these components:
+- Install Qt 6.7.1 ([Installer](https://download.qt.io/official_releases/online_installers/qt-unified-windows-x64-online.exe)) and select these components:
   - MSVC 2019 64-bit
   - Additional Libraries:
     - Qt WebEngine (display nexus pages)


### PR DESCRIPTION
This also removes the `> ` before the commands to make copying and pasting more convenient.